### PR TITLE
Fix: Added navigation links between Register and Login pages (#20)

### DIFF
--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -25,7 +25,6 @@ export const Login = () => {
       );
       dispatch({ type: "LOGINSUCC", payload: res.data });
 
-      // Show toast and redirect 
       toast.success("Login successful!", {
         position: "top-center",
         autoClose: 2000,
@@ -59,9 +58,12 @@ export const Login = () => {
               Log in
             </button>
 
-            <Link to="/register" className="link">
-              Register
-            </Link>
+            <p style={{ marginTop: "10px", textAlign: "center" }}>
+              Don't have an account?{" "}
+              <Link to="/register" className="link">
+                Create Account
+              </Link>
+            </p>        
           </form>
         </div>
         <ToastContainer />

--- a/src/pages/login/Regsiter.jsx
+++ b/src/pages/login/Regsiter.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom"; 
 import "./login.css";
 import back from "../../assets/images/my-account.jpg";
 import axios from "axios";
@@ -71,8 +72,16 @@ export const Regsiter = () => {
             <button type="submit" className="button">
               Register
             </button>
+
+            <p style={{ marginTop: "10px", textAlign: "center" }}>
+              Already have an account?{" "}
+              <Link to="/login" className="link">
+                Back to Login
+              </Link>
+            </p>
           </form>
-          {error && <span>Something went wrong</span>}
+
+          {error && <span style={{ color: "red" }}>Something went wrong</span>}
         </div>
         <ToastContainer />
       </section>


### PR DESCRIPTION
This PR resolves Issue #20 : Cannot Navigate Back to Login Page from Register Page.

🔧 Changes Made
- ✅ Added a "Back to Login" link on the Register page.
- ✅ Added a "Create Account" link on the Login page.
- ✅ Ensured both links are centered for better UI/UX consistency.

These changes improve user experience by allowing seamless navigation between the Login and Register pages.

---

Related Issue
Closes #20 
