### PR TITLE
Enhance Login and Register Pages with Colorful Background

### DIFF
--- a/src/pages/login/login.css
+++ b/src/pages/login/login.css
@@ -57,7 +57,7 @@
 .login-form {
   width: 100%;
   max-width: 400px;
-  background: white;
+  background: linear-gradient(135deg, #f5b8d9, #bdd9f9); 
   padding: 2.5rem;
   border-radius: 8px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
@@ -69,12 +69,16 @@
 .login-form h2 {
   margin-bottom: 1.5rem;
   text-align: center;
-  color: #333;
+  background: linear-gradient(90deg, #f90a86, #0472f8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-weight: bold;
+  font-size: 1.8rem;
 }
+
 @media (max-width: 640px) {
   .login-form h2 {
     font-size: 1.4rem;
-    color: #333;
   }
 }
 
@@ -82,7 +86,8 @@
   display: block;
   margin-bottom: 0.2rem;
   font-weight: bold;
-  color: #555;
+  color: rgb(30, 29, 29);
+  font-size: 0.9rem;
 }
 
 .form-group input {
@@ -91,13 +96,15 @@
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 1rem;
+  background-color: rgb(228, 245, 249);
+  ;
 }
 
-.form-group .button {
+.button {
   width: 100%;
   padding: 0.85rem;
   border: none;
-  background: linear-gradient(90deg, #D582E8, #A091D6);
+  background: linear-gradient(90deg, #f01b89, #1e7df2); 
   color: white;
   font-size: 1.1rem;
   font-weight: bold;
@@ -106,7 +113,7 @@
 }
 
 .button:disabled {
-  background: #1c279b;
+  background: #a5b4fc;
   cursor: not-allowed;
 }
 
@@ -126,7 +133,7 @@
   color: #555;
 }
 .register-link a {
-  color: #007bff;
+  color: #1984f7;
   text-decoration: none;
   font-weight: bold;
 }
@@ -161,10 +168,25 @@
   padding: 4px;
 }
 
+
+.login-form .button,
+.register-form .button {
+  background: linear-gradient(90deg, #f61e8e, #1876ea) !important; 
+  color: white !important;
+  font-weight: bold;
+  border: none !important;
+}
+
+.login-form .button:hover,
+.register-form .button:hover {
+  background: linear-gradient(90deg, #f580bb, #7eadf9) !important;
+}
+
 input::-ms-reveal,
 input::-ms-clear {
   display: none;
 }
+
 @media screen and (max-width: 768px) {
   .login-hero {
     height: 40vh;


### PR DESCRIPTION

Updated the overall background for the login and register pages to use a vibrant gradient, improving visual appeal and making the design more consistent. 
Changes include:
- Added a gradient background to .login-container for both pages.
- Ensured the background spans the full viewport height.
- Maintained readability and accessibility of the form content.

This closes the issue #97 


BEFORE:






AFTER:
