### PR TITLE
Fix#205-resources-links-updated

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -5,7 +5,7 @@ import { RiInstagramFill } from "react-icons/ri"
 import { MdEmail, MdPhone, MdLocationOn } from "react-icons/md"
 import logo from "../../assets/images/logo.png"
 import "./footer.css"
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
 function QuickLinks() {
   const navigate = useNavigate();
@@ -23,6 +23,9 @@ function QuickLinks() {
   );
 }
 export const Footer = () => {
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
   return (
     <footer className="footer">
       <div className="footer-container">
@@ -63,11 +66,11 @@ export const Footer = () => {
           <div className="footer-section">
             <h4>Resources</h4>
             <ul className="footer-links">
-              <li><a href="/about">About Us</a></li>
-              <li><a href="/contact">Contact</a></li>
-              <li><a href="/privacy">Privacy Policy</a></li>
-              <li><a href="/terms">Terms of Service</a></li>
-              <li><a href="/help">Help Center</a></li>
+              <li><Link to="/about" onClick={handleScrollToTop}>About Us</Link></li>
+              <li><Link to="/contact" onClick={handleScrollToTop}>Contact</Link></li>
+              <li><Link to="/privacy" onClick={handleScrollToTop}>Privacy Policy</Link></li>
+              <li><Link to="/terms" onClick={handleScrollToTop}>Terms of Service</Link></li>
+              <li><Link to="/help" onClick={handleScrollToTop}>Help Center</Link></li>
             </ul>
           </div>
 


### PR DESCRIPTION
**Issue**
Fixes #205: In resources section of footer, links embedded to items are invalid

**Problem**
The Resources section in the footer was using regular anchor tags (\<a href>) for navigation, which caused 404 errors on the hosted Netlify site. While these links worked correctly in development, they failed in production because:
- Static hosting services like Netlify don't have server-side routing to handle direct URL requests
- Regular anchor tags trigger full page requests to the server rather than client-side navigation

**Solution**
1. Replaced all \<a href> tags with React Router's \<Link to> components in the Resources section
2. Added scroll-to-top functionality to ensure consistent behavior with the QuickLinks section
3. Navigation now happens client-side through React Router, preventing 404 errors