### PR TITLE
Fix #276: Implement Click Outside to Close Profile Dropdown

### DIFF
--- a/src/components/header/User.jsx
+++ b/src/components/header/User.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useRef, useEffect } from "react";
 import { IoSettingsOutline } from "react-icons/io5";
 import { BsBagCheck } from "react-icons/bs";
 import { AiOutlineHeart } from "react-icons/ai";
@@ -8,17 +8,29 @@ import { RiImageAddLine } from "react-icons/ri";
 import { Context } from "../../context/Context";
 import { Link, useNavigate } from "react-router-dom";
 import { FaTimes } from "react-icons/fa";
-import { toast, ToastContainer } from "react-toastify";
+import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { useClickOutside } from '../../hooks/useClickOutside';
 
 export const User = ({ closeMobileMenu, profileOpen: propProfileOpen, setProfileOpen: propSetProfileOpen, toggleProfileOnly, showProfileOnly, isMobile }) => {
   const { user, dispatch } = useContext(Context);
   const navigate = useNavigate();
+  const profileRef = useRef(null);
 
   const [localProfileOpen, setLocalProfileOpen] = useState(false);
 
   const currentProfileOpen = isMobile ? propProfileOpen : localProfileOpen;
   const currentSetProfileOpen = isMobile ? propSetProfileOpen : setLocalProfileOpen;
+
+  useClickOutside(profileRef, () => {
+    if (isMobile) {
+      if (showProfileOnly) {
+        toggleProfileOnly();
+      }
+    } else {
+      currentSetProfileOpen(false);
+    }
+  });
 
   const handleLogout = () => {
     dispatch({ type: "LOGOUT" });
@@ -35,107 +47,103 @@ export const User = ({ closeMobileMenu, profileOpen: propProfileOpen, setProfile
   const PublicFlo = "https://taara-backend.onrender.com/images/";
 
   return (
-    <>
-      <div className="profile">
-        {user ? (
-          <>
-            {!showProfileOnly && (
-              <button
-                className="img"
-                onClick={() => {
-                  if (isMobile) {
-                    toggleProfileOnly(); // Use toggleProfileOnly for mobile
-                  } else {
-                    currentSetProfileOpen(!currentProfileOpen); // Toggle desktop profile dropdown
-                  }
-                }}
-              >
-                <img
-                  src="https://www.blookup.com/static/images/single/profile-1.edaddfbacb02.png"
-                  alt=""
-                />
-              </button>
-            )}
-            {/* Desktop Profile Dropdown */}
-            {currentProfileOpen && !isMobile && (
-              <div className="openProfile boxItems">
-                <Link to={"/account"} onClick={() => currentSetProfileOpen(false)}>
-                  <div className="image">
-                    <div className="img">
-                      <img
-                        src="https://www.blookup.com/static/images/single/profile-1.edaddfbacb02.png"
-                        alt=""
-                      />
-                    </div>
-                    <div className="text">
-                      <h4>{user.username}</h4>
-                      <label>India, Delhi</label>
-                    </div>
+    <div className="profile" ref={profileRef}>
+      {user ? (
+        <>
+          {!showProfileOnly && (
+            <button
+              className="img"
+              onClick={() => {
+                if (isMobile) {
+                  toggleProfileOnly();
+                } else {
+                  currentSetProfileOpen(!currentProfileOpen);
+                }
+              }}
+            >
+              <img
+                src="https://www.blookup.com/static/images/single/profile-1.edaddfbacb02.png"
+                alt=""
+              />
+            </button>
+          )}
+          {currentProfileOpen && !isMobile && (
+            <div className="openProfile boxItems" onClick={e => e.stopPropagation()}>
+              <Link to={"/account"} onClick={() => currentSetProfileOpen(false)}>
+                <div className="image">
+                  <div className="img">
+                    <img
+                      src="https://www.blookup.com/static/images/single/profile-1.edaddfbacb02.png"
+                      alt=""
+                    />
                   </div>
-                </Link>
-                <button className="box" onClick={() => {navigate("/create"); currentSetProfileOpen(false);}} >
-                  <RiImageAddLine className="icon" />
-                  <h4>Create Post</h4>
-                </button>
-                <button className="box" onClick={() => {navigate("/account"); currentSetProfileOpen(false);}} >
-                  <IoSettingsOutline className="icon" />
-                  <h4>My Account</h4>
-                </button>
-                <button className="box" onClick={() => {navigate("/help"); currentSetProfileOpen(false);}} >
-                  <GrHelp className="icon" />
-                  <h4>Help</h4>
-                </button>
-                <button className="box" onClick={() => {handleLogout(); currentSetProfileOpen(false);}}>
-                  <BiLogOut className="icon" />
-                  {user && <h4>Log Out</h4>}
-                </button>
-              </div>
-            )}
-            {/* Mobile Profile Drawer Content */}
-            {showProfileOnly && isMobile && (
-                <div className="openProfile boxItems">
-                   <button className="closeProfileMenu" onClick={toggleProfileOnly}>
-                     <FaTimes />
-                   </button>
-                  <Link to={"/account"} onClick={() => {console.log('Clicked My Account Link (Mobile Drawer)'); navigate("/account"); closeMobileMenu();}}>
-                    <div className="image">
-                      <div className="img">
-                        <img
-                          src="https://www.blookup.com/static/images/single/profile-1.edaddfbacb02.png"
-                          alt=""
-                        />
-                      </div>
-                      <div className="text">
-                        <h4>{user.username}</h4>
-                        <label>India, Delhi</label>
-                      </div>
-                    </div>
-                  </Link>
-                  <button className="box" onClick={() => {console.log('Clicked Create Post (Mobile Drawer)'); navigate("/create"); closeMobileMenu();}} >
-                    <RiImageAddLine className="icon" />
-                    <h4>Create Post</h4>
-                  </button>
-                  <button className="box" onClick={() => {console.log('Clicked My Account Button (Mobile Drawer)'); navigate("/account"); closeMobileMenu();}} >
-                    <IoSettingsOutline className="icon" />
-                    <h4>My Account</h4>
-                  </button>
-                  <button className="box" onClick={() => {console.log('Clicked Help (Mobile Drawer)'); navigate("/help"); closeMobileMenu();}} >
-                    <GrHelp className="icon" />
-                    <h4>Help</h4>
-                  </button>
-                  <button className="box" onClick={() => {console.log('Clicked Log Out (Mobile Drawer)'); handleLogout();}}>
-                    <BiLogOut className="icon" />
-                    {user && <h4>Log Out</h4>}
-                  </button>
+                  <div className="text">
+                    <h4>{user.username}</h4>
+                    <label>India, Delhi</label>
+                  </div>
                 </div>
-            )}
-          </>
-        ) : (
-          <Link to="/login" onClick={closeMobileMenu}>
-            <button>My Account</button>
-          </Link>
-        )}
-      </div>
-    </>
+              </Link>
+              <button className="box" onClick={() => {navigate("/create"); currentSetProfileOpen(false);}}>
+                <RiImageAddLine className="icon" />
+                <h4>Create Post</h4>
+              </button>
+              <button className="box" onClick={() => {navigate("/account"); currentSetProfileOpen(false);}}>
+                <IoSettingsOutline className="icon" />
+                <h4>My Account</h4>
+              </button>
+              <button className="box" onClick={() => {navigate("/help"); currentSetProfileOpen(false);}}>
+                <GrHelp className="icon" />
+                <h4>Help</h4>
+              </button>
+              <button className="box" onClick={() => {handleLogout(); currentSetProfileOpen(false);}}>
+                <BiLogOut className="icon" />
+                <h4>Log Out</h4>
+              </button>
+            </div>
+          )}
+          {showProfileOnly && isMobile && (
+            <div className="openProfile boxItems" onClick={e => e.stopPropagation()}>
+              <button className="closeProfileMenu" onClick={toggleProfileOnly}>
+                <FaTimes />
+              </button>
+              <Link to={"/account"} onClick={closeMobileMenu}>
+                <div className="image">
+                  <div className="img">
+                    <img
+                      src="https://www.blookup.com/static/images/single/profile-1.edaddfbacb02.png"
+                      alt=""
+                    />
+                  </div>
+                  <div className="text">
+                    <h4>{user.username}</h4>
+                    <label>India, Delhi</label>
+                  </div>
+                </div>
+              </Link>
+              <button className="box" onClick={() => {navigate("/create"); closeMobileMenu();}}>
+                <RiImageAddLine className="icon" />
+                <h4>Create Post</h4>
+              </button>
+              <button className="box" onClick={() => {navigate("/account"); closeMobileMenu();}}>
+                <IoSettingsOutline className="icon" />
+                <h4>My Account</h4>
+              </button>
+              <button className="box" onClick={() => {navigate("/help"); closeMobileMenu();}}>
+                <GrHelp className="icon" />
+                <h4>Help</h4>
+              </button>
+              <button className="box" onClick={handleLogout}>
+                <BiLogOut className="icon" />
+                <h4>Log Out</h4>
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <Link to="/login" onClick={closeMobileMenu}>
+          <button>My Account</button>
+        </Link>
+      )}
+    </div>
   );
 };

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export function useClickOutside(ref, callback) {
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback(event);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, callback]);
+}


### PR DESCRIPTION
This pr closes issue #276 .

- Added a custom useClickOutside hook to handle click-outside functionality
- Fixed the profile dropdown to close when clicking outside on both mobile and desktop views
- Improved the toggle behavior for better user experience
- Ensured proper cleanup of event listeners
- Maintained existing functionality while adding the new feature

The changes make the profile dropdown behavior more intuitive by closing when clicking anywhere outside the dropdown.